### PR TITLE
Collision events give object ids of colliding objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ NOTE: On VS2017 the Windows 8.1 SDK and the UCRT SD must be installed since this
 Also the target must be retargeted for the newest platform tools.
 To do so, right click the solution file in Visual Studio and click _Retarget Project_.
 
-image::vs2015-2017.png
-
 Overall the required folder structure for dependencies (with version implied) is:
 ```
 WienerTakesAll

--- a/WienerTakesAll.vcxproj
+++ b/WienerTakesAll.vcxproj
@@ -83,7 +83,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>PsFastXmlDEBUG_x86.lib;PxFoundationDEBUG_x86.lib;PxPvdSDKDEBUG_x86.lib;PxTaskDEBUG_x86.lib;LowLevelAABBDEBUG.lib;LowLevelParticlesDEBUG.lib;PhysX3DEBUG_x86.lib;SimulationControllerDEBUG.lib;LowLevelClothDEBUG.lib;PhysX3CharacterKinematicDEBUG_x86.lib;PhysX3ExtensionsDEBUG.lib;LowLevelDEBUG.lib;PhysX3CommonDEBUG_x86.lib;PhysX3VehicleDEBUG.lib;LowLevelDynamicsDEBUG.lib;PhysX3CookingDEBUG_x86.lib;SceneQueryDEBUG.lib;assimp-vc140-mt.lib;glew32.lib;glew32s.lib;opengl32.lib;SDL2.lib;SDL2_mixer.lib;SDL2main.lib;SDL2test.lib;libyaml-cppmdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>PsFastXmlDEBUG_x86.lib;PxFoundationDEBUG_x86.lib;PxPvdSDKDEBUG_x86.lib;PxTaskDEBUG_x86.lib;LowLevelAABBDEBUG.lib;LowLevelParticlesDEBUG.lib;PhysX3DEBUG_x86.lib;SimulationControllerDEBUG.lib;LowLevelClothDEBUG.lib;PhysX3CharacterKinematicDEBUG_x86.lib;PhysX3ExtensionsDEBUG.lib;LowLevelDEBUG.lib;PhysX3CommonDEBUG_x86.lib;PhysX3VehicleDEBUG.lib;LowLevelDynamicsDEBUG.lib;PhysX3CookingDEBUG_x86.lib;SceneQueryDEBUG.lib;assimp-vc140-mt.lib;glew32.lib;glew32s.lib;opengl32.lib;SDL2.lib;SDL2_mixer.lib;SDL2main.lib;SDL2test.lib;SDL2_image.lib;libyaml-cppmdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -104,6 +104,7 @@
   <ItemGroup>
     <ClCompile Include="src\AssetManager.cpp" />
     <ClCompile Include="src\AudioSystem.cpp" />
+    <ClCompile Include="src\CollisionEventsSubsystem.cpp" />
     <ClCompile Include="src\Event.cpp" />
     <ClCompile Include="src\FrictionPairService.cpp" />
     <ClCompile Include="src\GameObject.cpp" />
@@ -119,6 +120,10 @@
     <ClCompile Include="src\RenderingSystem.cpp" />
     <ClCompile Include="src\SettingsSystem.cpp" />
     <ClCompile Include="src\Shader.cpp" />
+    <ClCompile Include="src\ShaderAsset.cpp" />
+    <ClCompile Include="src\TextureAsset.cpp" />
+    <ClCompile Include="src\UIObject.cpp" />
+    <ClCompile Include="src\UISystem.cpp" />
     <ClCompile Include="src\VehicleSceneQueryData.cpp" />
     <ClCompile Include="src\VehicleWheelQueryResults.cpp" />
     <ClCompile Include="src\WheelMeshGenerator.cpp" />
@@ -128,6 +133,7 @@
     <ClInclude Include="src\AudioSettings.h" />
     <ClInclude Include="src\AudioSystem.h" />
     <ClInclude Include="src\CarControlType.h" />
+    <ClInclude Include="src\CollisionEventsSubsystem.h" />
     <ClInclude Include="src\CollisionFlags.h" />
     <ClInclude Include="src\Event.h" />
     <ClInclude Include="src\EventSystem.h" />
@@ -151,8 +157,13 @@
     <ClInclude Include="src\RenderingComponent.h" />
     <ClInclude Include="src\RenderingSystem.h" />
     <ClInclude Include="src\SettingsSystem.h" />
+    <ClInclude Include="src\SettingsSystem_impl.h" />
     <ClInclude Include="src\Shader.h" />
+    <ClInclude Include="src\ShaderAsset.h" />
     <ClInclude Include="src\SoundAsset.h" />
+    <ClInclude Include="src\TextureAsset.h" />
+    <ClInclude Include="src\UIObject.h" />
+    <ClInclude Include="src\UISystem.h" />
     <ClInclude Include="src\VehicleControls.h" />
     <ClInclude Include="src\VehicleSceneQueryData.h" />
     <ClInclude Include="src\VehicleWheelQueryResults.h" />

--- a/WienerTakesAll.vcxproj.filters
+++ b/WienerTakesAll.vcxproj.filters
@@ -75,6 +75,21 @@
     <ClCompile Include="src\SettingsSystem.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\CollisionEventsSubsystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ShaderAsset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\TextureAsset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\UIObject.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\UISystem.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Shader.h">
@@ -177,6 +192,24 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\SettingsSystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\CollisionEventsSubsystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\SettingsSystem_impl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ShaderAsset.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\TextureAsset.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\UIObject.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\UISystem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/AudioSystem.cpp
+++ b/src/AudioSystem.cpp
@@ -64,6 +64,9 @@ void AudioSystem::handle_update_settings_event(const Event& event) {
 }
 
 void AudioSystem::handle_vehicle_collision_event(const Event& e) {
+    int a_id = e.get_value<int>("a_id", true).first;
+    int b_id = e.get_value<int>("b_id", true).first;
+    std::cout << a_id << " collided with " << b_id << std::endl;
     play_sound(SoundAsset::BEAT);
 }
 

--- a/src/CollisionEventsSubsystem.cpp
+++ b/src/CollisionEventsSubsystem.cpp
@@ -34,7 +34,9 @@ void CollisionEventsSubsystem::onContact(
     const physx::PxContactPair* pairs,
     physx::PxU32 nbPairs
 ) {
-    collisions_.emplace_back(0, 0);
+    int a_id = *(int*)pairHeader.actors[0]->userData;
+    int b_id = *(int*)pairHeader.actors[1]->userData;
+    collisions_.emplace_back(a_id, b_id);
 }
 
 void CollisionEventsSubsystem::onTrigger(

--- a/src/PhysicsComponent.cpp
+++ b/src/PhysicsComponent.cpp
@@ -7,6 +7,7 @@ void PhysicsComponent<true>::create_actor(
     physx::PxShape* shape, physx::PxReal density
 ) {
     g_actor_ = physx::PxCreateStatic(*physics, transform, *shape);
+    g_actor_->userData = &id_;
 }
 
 template <>
@@ -17,4 +18,5 @@ void PhysicsComponent<false>::create_actor(
     physx::PxReal density
 ) {
     g_actor_ = physics->createRigidDynamic(transform);
+    g_actor_->userData = &id_;
 }

--- a/src/PhysicsComponent.h
+++ b/src/PhysicsComponent.h
@@ -11,18 +11,21 @@ public:
     using PxActorType = typename std::conditional<static_actor, physx::PxRigidStatic, physx::PxRigidDynamic>::type;
 
     PhysicsComponent(unsigned int id);
+    PhysicsComponent(const PhysicsComponent& that);
+    PhysicsComponent& operator=(const PhysicsComponent& that);
     ~PhysicsComponent();
 
-    bool is_valid();
-    unsigned int get_id();
-    auto get_actor();
+    bool is_valid() const;
+    unsigned int get_id() const;
+    physx::PxMaterial* get_material() const;
+    physx::PxConvexMesh* get_mesh() const;
+    physx::PxConvexMeshGeometry* get_mesh_geometry() const;
+    physx::PxShape* get_mesh_shape() const;
+    auto get_actor() const;
+    bool is_vehicle() const;
+    physx::PxVehicleDrive4W* get_wheels() const;
+
     void set_actor(physx::PxRigidDynamic* actor);
-
-    physx::PxMaterial* get_material();
-    physx::PxConvexMesh* get_mesh();
-
-    physx::PxVehicleDrive4W* get_wheels();
-
     void set_mesh(
         physx::PxPhysics* physics,
         physx::PxCooking* cooking,

--- a/src/PhysicsComponent_impl.h
+++ b/src/PhysicsComponent_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <assert.h>
 
 #include "PhysicsSystemUtils.h"
@@ -15,42 +16,95 @@ PhysicsComponent<static_actor>::PhysicsComponent(unsigned int id)
 }
 
 template <bool static_actor>
+PhysicsComponent<static_actor>::PhysicsComponent(const PhysicsComponent& that)
+    : valid_(that.is_valid())
+    , id_(that.get_id())
+    , g_material_(that.get_material())
+    , g_mesh_(that.get_mesh())
+    , g_mesh_geometry_(that.get_mesh_geometry())
+    , g_mesh_shape_(that.get_mesh_shape())
+    , g_actor_(that.get_actor())
+    , is_vehicle_(that.is_vehicle())
+    , g_drive_4w_(that.get_wheels()) {
+    if (g_actor_) {
+        g_actor_->userData = &id_;
+    }
+}
+
+template <bool static_actor>
+PhysicsComponent<static_actor>& PhysicsComponent<static_actor>::operator=(const PhysicsComponent& that) {
+    valid_ = that.is_valid();
+    id_ = that.get_id();
+    g_material_ = that.get_material();
+    g_mesh_ = that.get_mesh();
+    g_mesh_geometry_ = that.get_mesh_geometry();
+    g_mesh_shape_ = that.get_mesh_shape();
+    g_actor_ = that.get_actor();
+    is_vehicle_ = that.is_vehicle();
+    g_drive_4w_ = that.get_wheels();
+
+    if (g_actor_) {
+        g_actor_->userData = &id_;
+    }
+
+    return *this;
+}
+
+template <bool static_actor>
 PhysicsComponent<static_actor>::~PhysicsComponent() {
 }
 
 template <bool static_actor>
-bool PhysicsComponent<static_actor>::is_valid() {
+bool PhysicsComponent<static_actor>::is_valid() const {
     return valid_;
 }
 
 template <bool static_actor>
-unsigned int PhysicsComponent<static_actor>::get_id() {
+unsigned int PhysicsComponent<static_actor>::get_id() const {
     return id_;
 }
 
 template <bool static_actor>
-auto PhysicsComponent<static_actor>::get_actor() {
-    return g_actor_;
-}
-
-template <bool static_actor>
-void PhysicsComponent<static_actor>::set_actor(physx::PxRigidDynamic* actor) {
-    g_actor_ = actor;
-}
-
-template <bool static_actor>
-physx::PxMaterial* PhysicsComponent<static_actor>::get_material() {
+physx::PxMaterial* PhysicsComponent<static_actor>::get_material() const {
     return g_material_;
 }
 
 template <bool static_actor>
-physx::PxConvexMesh* PhysicsComponent<static_actor>::get_mesh() {
+physx::PxConvexMesh* PhysicsComponent<static_actor>::get_mesh() const {
     return g_mesh_;
 }
 
 template <bool static_actor>
-physx::PxVehicleDrive4W* PhysicsComponent<static_actor>::get_wheels() {
+physx::PxConvexMeshGeometry* PhysicsComponent<static_actor>::get_mesh_geometry() const {
+    return g_mesh_geometry_;
+}
+
+template <bool static_actor>
+physx::PxShape* PhysicsComponent<static_actor>::get_mesh_shape() const {
+    return g_mesh_shape_;
+}
+
+template <bool static_actor>
+auto PhysicsComponent<static_actor>::get_actor() const {
+    return g_actor_;
+}
+
+template <bool static_actor>
+bool PhysicsComponent<static_actor>::is_vehicle() const {
+    return is_vehicle_;
+}
+
+template <bool static_actor>
+physx::PxVehicleDrive4W* PhysicsComponent<static_actor>::get_wheels() const {
     return g_drive_4w_;
+}
+
+template <bool static_actor>
+void PhysicsComponent<static_actor>::set_actor(physx::PxRigidDynamic* actor) {
+    std::cout << "set_actor id: " << id_ << std::endl;
+    g_actor_ = actor;
+    g_actor_->userData = &id_;
+    std::cout << "set_actor g_actor_->userData: " << *(int*)g_actor_->userData << std::endl;
 }
 
 template <bool static_actor>

--- a/src/PhysicsSystem.cpp
+++ b/src/PhysicsSystem.cpp
@@ -78,8 +78,8 @@ void PhysicsSystem::update() {
         EventSystem::queue_event(
             Event(
                 EventType::VEHICLE_COLLISION,
-                "vehicle_a", collision.first,
-                "vehicle_b", collision.second
+                "a_id", collision.first,
+                "b_id", collision.second
             )
         );
     }


### PR DESCRIPTION
Set userData of actors to be the object id of their parent in game
object. Added copy operator and constructor so that userData points to
correct id_ private member.