### PR TITLE
Made events complain less if not found

### DIFF
--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -44,8 +44,10 @@ std::pair<std::string, bool> Event::get_value(const std::string& name, bool cras
     if (val == string_values_.end()) {                          //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
 
-		if(crash_on_fail)
-			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        if (crash_on_fail) {
+            std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        }
+
         return std::make_pair("-1", false);
     }
 
@@ -58,8 +60,11 @@ std::pair<int, bool> Event::get_value(const std::string& name, bool crash_on_fai
 
     if (val == event_values_.end()) {
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
-		if (crash_on_fail)
-			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+
+        if (crash_on_fail) {
+            std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        }
+
         return std::make_pair(-1, false);
     }
 
@@ -82,8 +87,10 @@ std::pair<float, bool> Event::get_value(const std::string& name, bool crash_on_f
     if (val == event_values_.end()) {                           //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
 
-		if (crash_on_fail)
-			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        if (crash_on_fail) {
+            std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        }
+
         return std::make_pair(-1.0, false);
     }
 
@@ -104,8 +111,10 @@ std::pair<void*, bool> Event::get_value(const std::string& name, bool crash_on_f
     const auto val = event_values_.find(name);
 
     if (val == event_values_.end()) {
-		if (crash_on_fail)
-			std::cerr << "Value " << name << " not found in event" << static_cast<int>(event_type) << "!" << std::endl;
+        if (crash_on_fail) {
+            std::cerr << "Value " << name << " not found in event" << static_cast<int>(event_type) << "!" << std::endl;
+        }
+
         return std::make_pair(nullptr, false);
     }
 
@@ -128,8 +137,11 @@ std::pair<bool, bool> Event::get_value(const std::string& name, bool crash_on_fa
 
     if (val == event_values_.end()) {    //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
-		if (crash_on_fail)
-			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+
+        if (crash_on_fail) {
+            std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+        }
+
         return std::make_pair(false, false);
     }
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -44,7 +44,8 @@ std::pair<std::string, bool> Event::get_value(const std::string& name, bool cras
     if (val == string_values_.end()) {                          //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
 
-        std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+		if(crash_on_fail)
+			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
         return std::make_pair("-1", false);
     }
 
@@ -57,8 +58,8 @@ std::pair<int, bool> Event::get_value(const std::string& name, bool crash_on_fai
 
     if (val == event_values_.end()) {
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
-
-        std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+		if (crash_on_fail)
+			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
         return std::make_pair(-1, false);
     }
 
@@ -81,7 +82,8 @@ std::pair<float, bool> Event::get_value(const std::string& name, bool crash_on_f
     if (val == event_values_.end()) {                           //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
 
-        std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+		if (crash_on_fail)
+			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
         return std::make_pair(-1.0, false);
     }
 
@@ -102,7 +104,8 @@ std::pair<void*, bool> Event::get_value(const std::string& name, bool crash_on_f
     const auto val = event_values_.find(name);
 
     if (val == event_values_.end()) {
-        std::cerr << "Value " << name << " not found in event" << static_cast<int>(event_type) << "!" << std::endl;
+		if (crash_on_fail)
+			std::cerr << "Value " << name << " not found in event" << static_cast<int>(event_type) << "!" << std::endl;
         return std::make_pair(nullptr, false);
     }
 
@@ -125,8 +128,8 @@ std::pair<bool, bool> Event::get_value(const std::string& name, bool crash_on_fa
 
     if (val == event_values_.end()) {    //the case when crash on fail is not true and value is not found
         assert((!crash_on_fail));       //if the value is not found and crash_on_fail is true crash the program
-
-        std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
+		if (crash_on_fail)
+			std::cerr << "Value " << name << " not found in event " << static_cast<int>(event_type) << "!" << std::endl;
         return std::make_pair(false, false);
     }
 


### PR DESCRIPTION
Since velocity was only sometimes sent in the object transform event, I
made them stop throwing that annoying error message.